### PR TITLE
feat: full config management and support for 3 lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +395,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -590,6 +599,7 @@ dependencies = [
  "freedesktop-desktop-entry",
  "image",
  "log",
+ "ron",
  "serde",
  "svg",
  "xdg",
@@ -1693,6 +1703,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.11.3"
 freedesktop-desktop-entry = "0.5.2"
 image = "0.25.1"
 log = "0.4.21"
+ron = "0.8.1"
 serde = { version = "1.0.198", features = ["derive"] }
 svg = "0.16.0"
 xdg = "2.5.2"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,6 +22,7 @@ impl Into<zbus::fdo::Error> for EntryManagerError {
             Self::IO(e) => zbus::fdo::Error::IOError(e.to_string()),
             Self::IconValidation(e) => zbus::fdo::Error::InvalidArgs(e.to_string()),
             Self::PathCollision(p) => zbus::fdo::Error::FileExists(p.display().to_string()),
+            Self::Ron(r) => zbus::fdo::Error::IOError(r.to_string()),
         }
     }
 }


### PR DESCRIPTION
Complete support for the 3 provided lifetimes:

* Process - Follows the calling process
* Session - Follows the session
* Persistent - Completely persistent, must be manually removed

Cache configs can also be saved now